### PR TITLE
Add version to rock build

### DIFF
--- a/2.4.0/rockcraft.yaml
+++ b/2.4.0/rockcraft.yaml
@@ -24,7 +24,7 @@ parts:
     build-packages:
       - libsystemd-dev
     override-build: |
-      go build -o $CRAFT_PART_INSTALL/bin/tempo ./cmd/tempo
+      go build -o $CRAFT_PART_INSTALL/bin/tempo -ldflags "-X main.Version=${CRAFT_PROJECT_VERSION}" ./cmd/tempo
     stage:
       - bin/tempo
   default-config:

--- a/2.4.2/rockcraft.yaml
+++ b/2.4.2/rockcraft.yaml
@@ -24,7 +24,7 @@ parts:
     build-packages:
       - libsystemd-dev
     override-build: |
-      go build -o $CRAFT_PART_INSTALL/bin/tempo ./cmd/tempo
+      go build -o $CRAFT_PART_INSTALL/bin/tempo -ldflags "-X main.Version=${CRAFT_PROJECT_VERSION}" ./cmd/tempo
     stage:
       - bin/tempo
   default-config:

--- a/2.5.0/rockcraft.yaml
+++ b/2.5.0/rockcraft.yaml
@@ -24,7 +24,7 @@ parts:
     build-packages:
       - libsystemd-dev
     override-build: |
-      go build -o $CRAFT_PART_INSTALL/bin/tempo ./cmd/tempo
+      go build -o $CRAFT_PART_INSTALL/bin/tempo -ldflags "-X main.Version=2.5.0" ./cmd/tempo
     stage:
       - bin/tempo
   default-config:

--- a/2.5.0/rockcraft.yaml
+++ b/2.5.0/rockcraft.yaml
@@ -24,7 +24,7 @@ parts:
     build-packages:
       - libsystemd-dev
     override-build: |
-      go build -o $CRAFT_PART_INSTALL/bin/tempo -ldflags "-X main.Version=2.5.0" ./cmd/tempo
+      go build -o $CRAFT_PART_INSTALL/bin/tempo -ldflags "-X main.Version=${CRAFT_PROJECT_VERSION}" ./cmd/tempo
     stage:
       - bin/tempo
   default-config:


### PR DESCRIPTION
## Issue
Tempo rock didn't contain the `main.Version` flag, which caused tempo status metric not to contain the version parameter, showing "No data" in relevant dashboards.

Fixes #7 

## Solution
Use `CRAFT_PROJECT_VERSION` parameter to show up in the metrics.

![Screenshot from 2024-10-15 15-55-16](https://github.com/user-attachments/assets/fb373946-b68c-40ff-9b8f-0e341b223f8a)



## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
