### PR TITLE
chore: use `v1` workflows

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,5 +12,5 @@ on:
 jobs:
   pull-request:
     name: PR
-    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@v0
+    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@v1
     secrets: inherit

--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    uses: canonical/observability/.github/workflows/rock-release-dev.yaml@v0
+    uses: canonical/observability/.github/workflows/rock-release-dev.yaml@v1
     secrets: inherit
     with:
       rock-name: tempo

--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@v0
+    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@v1
     secrets: inherit
     with:
       rock-name: tempo

--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    uses: canonical/observability/.github/workflows/rock-update.yaml@v0
+    uses: canonical/observability/.github/workflows/rock-update.yaml@v1
     with:
       rock-name: tempo
       source-repo: grafana/tempo


### PR DESCRIPTION
## Issue
We were using an old `v0` tag for this rock workflows


## Solution
Update all workflow files to use `v1`

